### PR TITLE
Features/lv2groups (draft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ utils/test
 *node_modules/
 .idea
 *.egg-info
+.vscode

--- a/example-port-group-ttls/tap_dynamics.ttl
+++ b/example-port-group-ttls/tap_dynamics.ttl
@@ -1,0 +1,197 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix epp: <http://lv2plug.in/ns/ext/port-props/#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mod: <http://moddevices.com/ns/mod#>.
+@prefix epg: <http://lv2plug.in/ns/ext/port-groups#> .
+
+@prefix tap_dynamics_lv2: <http://moddevices.com/plugins/tap/dynamics>.
+
+<http://moddevices.com/plugins/tap/dynamics>
+a lv2:Plugin, lv2:DynamicsPlugin;
+
+doap:name "TAP Mono Dynamics";
+
+
+doap:developer [
+    foaf:name "Tom Szilagyi";
+    foaf:homepage <http://tap-plugins.sourceforge.net>;
+    foaf:mbox <mailto:tsziagyi@users.sourceforge.net>;
+    ];
+
+doap:maintainer [
+    foaf:name "MOD Team";
+    foaf:homepage <http://moddevices.com>;
+    foaf:mbox <mailto:devel@moddevices.com>;
+    ];
+
+mod:brand "TAP";
+mod:label "Mono Dynamics";
+
+doap:license <http://usefulinc.com/doap/licenses/gpl>;
+lv2:minorVersion 7;
+lv2:microVersion 2;
+
+rdfs:comment """
+TAP Dynamics is a versatile tool for changing the dynamic content of your tracks. Currently it supports 15 dynamics transfer functions, among which there are compressors, limiters, expanders and noise gates. However, the plugin itself supports arbitrary dynamics transfer functions, so you may add your own functions as well, without any actual programming.
+
+The plugin comes in two versions: Mono (M) and Stereo (St). This is needed because independent processing of two channels is not always desirable in the case of stereo material. The stereo version has an additional control to set the appropriate mode for stereo processing (you may still choose to process the two channels independently, although the same effect is achieved by using the mono version).
+
+source: http://tap-plugins.sourceforge.net/ladspa/dynamics.html
+""";
+
+lv2:port
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 0;
+    lv2:symbol "attack";
+    lv2:name "Attack";
+    lv2:default 128;
+    lv2:minimum 4;
+    lv2:maximum 500;
+    epg:group tap_dynamics_lv2:DYN_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 1;
+    lv2:symbol "release";
+    lv2:name "Release";
+    lv2:default 502;
+    lv2:minimum 4;
+    lv2:maximum 1000;
+    epg:group tap_dynamics_lv2:DYN_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 2;
+    lv2:symbol "offset";
+    lv2:name "Offset Gain";
+    lv2:default 0;
+    lv2:minimum -20;
+    lv2:maximum 20;
+    epg:group tap_dynamics_lv2:GAIN_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 3;
+    lv2:symbol "makeup";
+    lv2:name "Makeup Gain";
+    lv2:default 0;
+    lv2:minimum -20;
+    lv2:maximum 20;
+    epg:group tap_dynamics_lv2:GAIN_GROUP ;
+],
+[
+    a lv2:OutputPort, lv2:ControlPort;
+    lv2:index 4;
+    lv2:symbol "envelope";
+    lv2:name "Envelope Volume";
+    lv2:default 0;
+    lv2:minimum -60;
+    lv2:maximum 20;
+],
+[
+    a lv2:OutputPort, lv2:ControlPort;
+    lv2:index 5;
+    lv2:symbol "adjustment";
+    lv2:name "Gain Adjustment";
+    lv2:default 0;
+    lv2:minimum -60;
+    lv2:maximum 20;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 6;
+    lv2:symbol "function";
+    lv2:name "Function";
+    lv2:default 0;
+    lv2:minimum 0;
+    lv2:maximum 14;
+    lv2:portProperty lv2:integer;
+    lv2:portProperty lv2:enumeration ;
+    epg:group tap_dynamics_lv2:DYN_GROUP ;
+    lv2:scalePoint
+    [
+        rdfs:label "2:1 comp at -6 dB";
+        rdf:value 0
+    ],
+    [
+        rdfs:label "2:1 comp at -9 dB";
+        rdf:value 1
+    ],
+    [
+        rdfs:label "2:1 comp at -12 dB";
+        rdf:value 2
+    ],
+    [
+        rdfs:label "2:1 comp at -18 dB";
+        rdf:value 3
+    ],
+    [
+        rdfs:label "2.5:1 comp at -12 dB";
+        rdf:value 4
+    ],
+    [
+        rdfs:label "3:1 comp at -12 dB";
+        rdf:value 5
+    ],
+    [
+        rdfs:label "3:1 comp at -15 dB";
+        rdf:value 6
+    ],
+    [
+        rdfs:label "Compressor/Gate";
+        rdf:value 7
+    ],
+    [
+        rdfs:label "Expander";
+        rdf:value 8
+    ],
+    [
+        rdfs:label "Hard limiter at -6 dB";
+        rdf:value 9
+    ],
+    [
+        rdfs:label "Hard limiter at -12 dB";
+        rdf:value 10
+    ],
+    [
+        rdfs:label "Hard gate at -35 dB";
+        rdf:value 11
+    ],
+    [
+        rdfs:label "Soft limiter";
+        rdf:value 12
+    ],
+    [
+        rdfs:label "Soft knee comp/gate";
+        rdf:value 13
+    ],
+    [
+        rdfs:label "Soft gate below -36 dB";
+        rdf:value 14
+    ]
+],
+[
+    a lv2:InputPort, lv2:AudioPort;
+    lv2:index 7;
+    lv2:symbol "input";
+    lv2:name "Input";
+],
+[
+    a lv2:OutputPort, lv2:AudioPort;
+    lv2:index 8;
+    lv2:symbol "output";
+    lv2:name "Output";
+].
+
+tap_dynamics_lv2:DYN_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "DYN" ;
+	lv2:name "Dynamics" .
+tap_dynamics_lv2:GAIN_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "GAIN" ;
+	lv2:name "GAIN" .

--- a/example-port-group-ttls/tap_echo.ttl
+++ b/example-port-group-ttls/tap_echo.ttl
@@ -1,0 +1,181 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix epp: <http://lv2plug.in/ns/ext/port-props/#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix mod: <http://moddevices.com/ns/mod#>.
+@prefix time: <http://lv2plug.in/ns/ext/time/#>.
+@prefix units: <http://lv2plug.in/ns/extensions/units#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix epg: <http://lv2plug.in/ns/ext/port-groups#> .
+
+@prefix tap_echo_lv2: <http://moddevices.com/plugins/tap/echo>.
+
+<http://moddevices.com/plugins/tap/echo>
+    a lv2:Plugin, lv2:DelayPlugin;
+
+doap:name "TAP Stereo Echo";
+
+doap:developer [
+    foaf:name "Tom Szilagyi";
+    foaf:homepage <http://tap-plugins.sourceforge.net/>;
+    foaf:mbox <mailto:tsziagyi@users.sourceforge.net>;
+    ];
+
+doap:maintainer [
+    foaf:name "MOD Team";
+    foaf:homepage <http://moddevices.com>;
+    foaf:mbox <mailto:devel@moddevices.com>;
+    ];
+
+mod:brand "TAP";
+mod:label "Stereo Echo";
+
+doap:license <http://usefulinc.com/doap/licenses/gpl>;
+lv2:optionalFeature lv2:hardRTCapable;
+lv2:minorVersion 7;
+lv2:microVersion 2;
+
+rdfs:comment """
+This plugin supports conventional mono and stereo delays, ping-pong delays and the Haas effect (also known as Cross Delay Stereo). A relatively simple yet quite effective plugin.
+
+source: http://tap-plugins.sourceforge.net/ladspa/echo.html
+""";
+
+lv2:port
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 0;
+    lv2:symbol "ldelay";
+    lv2:name "L Delay";
+    lv2:default 300;
+    lv2:minimum 0;
+    lv2:maximum 2000;
+    lv2:designation  time:beatsPerMinute;
+    units:unit units:ms ;
+    epg:group tap_echo_lv2:LEFT_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 1;
+    lv2:symbol "lfeedback";
+    lv2:name "Left Feedback";
+    lv2:default 50;
+    lv2:minimum 0;
+    lv2:maximum 100;
+    epg:group tap_echo_lv2:LEFT_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 2;
+    lv2:symbol "rhaasdelay";
+    lv2:name "Right Haas Delay";
+    lv2:default 300;
+    lv2:minimum 0;
+    lv2:maximum 2000;
+    lv2:designation  time:beatsPerMinute;
+    units:unit units:ms ;
+    epg:group tap_echo_lv2:RIGHT_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 3;
+    lv2:symbol "rhaasfeedback";
+    lv2:name "Right Haas Feedback";
+    lv2:default 50;
+    lv2:minimum 0;
+    lv2:maximum 100;
+    epg:group tap_echo_lv2:RIGHT_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 4;
+    lv2:symbol "lecholevel";
+    lv2:name "Left Echo Level";
+    lv2:default -4;
+    lv2:minimum -70;
+    lv2:maximum 10;
+    epg:group tap_echo_lv2:LEFT_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 5;
+    lv2:symbol "recholevel";
+    lv2:name "Right Echo Level";
+    lv2:default -4;
+    lv2:minimum -70;
+    lv2:maximum 10;
+    epg:group tap_echo_lv2:RIGHT_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 6;
+    lv2:symbol "dryLevel";
+    lv2:name "Dry Level";
+    lv2:default -4;
+    lv2:minimum -70;
+    lv2:maximum 10;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 7;
+    lv2:symbol "crossmode";
+    lv2:name "Cross Mode";
+    lv2:default 1;
+    lv2:minimum 0;
+    lv2:maximum 1;
+    lv2:portProperty lv2:toggled;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 8;
+    lv2:symbol "haaseffect";
+    lv2:name "Haas Effect";
+    lv2:default 0;
+    lv2:minimum 0;
+    lv2:maximum 1;
+    lv2:portProperty lv2:toggled;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 9;
+    lv2:symbol "swapoutputs";
+    lv2:name "Swap Outputs";
+    lv2:default 0;
+    lv2:minimum 0;
+    lv2:maximum 1;
+    lv2:portProperty lv2:toggled;
+],
+[
+    a lv2:InputPort, lv2:AudioPort;
+    lv2:index 10;
+    lv2:symbol "inputleft";
+    lv2:name "Input Left";
+],
+[
+    a lv2:OutputPort, lv2:AudioPort;
+    lv2:index 11;
+    lv2:symbol "outputleft";
+    lv2:name "Output Left";
+],
+[
+    a lv2:InputPort, lv2:AudioPort;
+    lv2:index 12;
+    lv2:symbol "inputright";
+    lv2:name "Input Right";
+],
+[
+    a lv2:OutputPort, lv2:AudioPort;
+    lv2:index 13;
+    lv2:symbol "outputright";
+    lv2:name "Output Right";
+].
+
+
+tap_echo_lv2:LEFT_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "LEFT" ;
+	lv2:name "LEFT" .
+tap_echo_lv2:RIGHT_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "RIGHT" ;
+	lv2:name "Right" .

--- a/example-port-group-ttls/tap_eq.ttl
+++ b/example-port-group-ttls/tap_eq.ttl
@@ -1,0 +1,249 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix epp: <http://lv2plug.in/ns/ext/port-props/#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mod: <http://moddevices.com/ns/mod#>.
+@prefix epg: <http://lv2plug.in/ns/ext/port-groups#> .
+
+@prefix tap_eq_lv2: <http://moddevices.com/plugins/tap/eq#>.
+
+<http://moddevices.com/plugins/tap/eq>
+a lv2:Plugin, lv2:EQPlugin;
+
+doap:name "TAP Equalizer";
+
+mod:brand "TAP";
+mod:label "Equalizer";
+
+doap:developer [
+    foaf:name "Tom Szilagyi";
+    foaf:homepage <http://tap-plugins.sourceforge.net/>;
+    foaf:mbox <mailto:tsziagyi@users.sourceforge.net>;
+];
+
+doap:maintainer [
+    foaf:name "MOD Team";
+    foaf:homepage <http://moddevices.com>;
+    foaf:mbox <mailto:devel@moddevices.com>;
+];
+
+mod:brand "TAP";
+mod:label "Equalizer";
+
+doap:license <http://usefulinc.com/doap/licenses/gpl>;
+lv2:minorVersion 7;
+lv2:microVersion 2;
+
+rdfs:comment """
+This plugin is an 8-band equalizer with adjustable band center frequencies. It allows you to make precise adjustments to the tonal coloration of your tracks. The design and code of this plugin is based on that of the DJ EQ plugin by Steve Harris, which can be downloaded (among lots of other useful plugins) from http://plugin.org.uk.
+
+source: http://tap-plugins.sourceforge.net/ladspa/eq.html
+""";
+
+lv2:port
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 0;
+    lv2:symbol "Band1GainDb";
+    lv2:name "Band 1 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND1_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 1;
+    lv2:symbol "Band2GainDb";
+    lv2:name "Band 2 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND2_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 2;
+    lv2:symbol "Band3GainDb";
+    lv2:name "Band 3 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND3_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 3;
+    lv2:symbol "Band4GainDb";
+    lv2:name "Band 4 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND4_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 4;
+    lv2:symbol "Band5GainDb";
+    lv2:name "Band 5 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND5_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 5;
+    lv2:symbol "Band6GainDb";
+    lv2:name "Band 6 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND6_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 6;
+    lv2:symbol "Band7GainDb";
+    lv2:name "Band 7 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND7_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 7;
+    lv2:symbol "Band8GainDb";
+    lv2:name "Band 8 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eq_lv2:BAND8_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 8;
+    lv2:symbol "Band1FreqHz";
+    lv2:name "Band 1 Freq [Hz]";
+    lv2:default 100;
+    lv2:minimum 40;
+    lv2:maximum 280;
+    epg:group tap_eq_lv2:BAND1_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 9;
+    lv2:symbol "Band2FreqHz";
+    lv2:name "Band 2 Freq [Hz]";
+    lv2:default 200;
+    lv2:minimum 100;
+    lv2:maximum 500;
+    epg:group tap_eq_lv2:BAND2_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 10;
+    lv2:symbol "Band3FreqHz";
+    lv2:name "Band 3 Freq [Hz]";
+    lv2:default 400;
+    lv2:minimum 200;
+    lv2:maximum 1000;
+    epg:group tap_eq_lv2:BAND3_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 11;
+    lv2:symbol "Band4FreqHz";
+    lv2:name "Band 4 Freq [Hz]";
+    lv2:default 1000;
+    lv2:minimum 400;
+    lv2:maximum 2800;
+    epg:group tap_eq_lv2:BAND4_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 12;
+    lv2:symbol "Band5FreqHz";
+    lv2:name "Band 5 Freq [Hz]";
+    lv2:default 3000;
+    lv2:minimum 1000;
+    lv2:maximum 5000;
+    epg:group tap_eq_lv2:BAND5_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 13;
+    lv2:symbol "Band6FreqHz";
+    lv2:name "Band 6 Freq [Hz]";
+    lv2:default 6000;
+    lv2:minimum 3000;
+    lv2:maximum 9000;
+    epg:group tap_eq_lv2:BAND6_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 14;
+    lv2:symbol "Band7FreqHz";
+    lv2:name "Band 7 Freq [Hz]";
+    lv2:default 12000;
+    lv2:minimum 6000;
+    lv2:maximum 18000;
+    epg:group tap_eq_lv2:BAND7_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 15;
+    lv2:symbol "Band8FreqHz";
+    lv2:name "Band 8 Freq [Hz]";
+    lv2:default 15000;
+    lv2:minimum 10000;
+    lv2:maximum 20000;
+    epg:group tap_eq_lv2:BAND8_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:AudioPort;
+    lv2:index 16;
+    lv2:symbol "Input";
+    lv2:name "Input";
+],
+[
+    a lv2:OutputPort, lv2:AudioPort;
+    lv2:index 17;
+    lv2:symbol "Output";
+    lv2:name "Output";
+].
+
+tap_eq_lv2:BAND1_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND1" ;
+	lv2:name "Band 1" .
+tap_eq_lv2:BAND2_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND2" ;
+	lv2:name "Band 2" .
+tap_eq_lv2:BAND3_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND3" ;
+	lv2:name "Band 3" .
+tap_eq_lv2:BAND4_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND4" ;
+	lv2:name "Band 4" .
+tap_eq_lv2:BAND5_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND5" ;
+	lv2:name "Band 5" .
+tap_eq_lv2:BAND6_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND6" ;
+	lv2:name "Band 6" .
+tap_eq_lv2:BAND7_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND7" ;
+	lv2:name "Band 7" .
+tap_eq_lv2:BAND8_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND8" ;
+	lv2:name "Band 8" .

--- a/example-port-group-ttls/tap_eqbw.ttl
+++ b/example-port-group-ttls/tap_eqbw.ttl
@@ -1,0 +1,329 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix epp: <http://lv2plug.in/ns/ext/port-props/#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mod: <http://moddevices.com/ns/mod#>.
+@prefix epg: <http://lv2plug.in/ns/ext/port-groups#> .
+
+@prefix tap_eqbw_lv2: <http://moddevices.com/plugins/tap/eqbw#>.
+
+<http://moddevices.com/plugins/tap/eqbw>
+a lv2:Plugin, lv2:EQPlugin;
+
+doap:name "TAP Equalizer/BW";
+
+mod:brand "TAP";
+mod:label "Equalizer/BW";
+
+doap:developer [
+    foaf:name "Tom Szilagyi";
+    foaf:homepage <http://tap-plugins.sourceforge.net/>;
+    foaf:mbox <mailto:tsziagyi@users.sourceforge.net>;
+];
+
+doap:maintainer [
+    foaf:name "MOD Team";
+    foaf:homepage <http://moddevices.com>;
+    foaf:mbox <mailto:devel@moddevices.com>;
+];
+
+mod:brand "TAP";
+mod:label "Equalizer/B";
+
+doap:license <http://usefulinc.com/doap/licenses/gpl>;
+lv2:minorVersion 7;
+lv2:microVersion 2;
+
+rdfs:comment """
+This plugin is an 8-band equalizer with adjustable band center frequencies. It allows you to make precise adjustments to the tonal coloration of your tracks. The design and code of this plugin is based on that of the DJ EQ plugin by Steve Harris, which can be downloaded (among lots of other useful plugins) from http://plugin.org.uk.
+
+source: http://tap-plugins.sourceforge.net/ladspa/eq.html
+""";
+
+lv2:port
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 0;
+    lv2:symbol "Band1GainDb";
+    lv2:name "Band 1 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND1_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 1;
+    lv2:symbol "Band2GainDb";
+    lv2:name "Band 2 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND2_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 2;
+    lv2:symbol "Band3GainDb";
+    lv2:name "Band 3 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND3_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 3;
+    lv2:symbol "Band4GainDb";
+    lv2:name "Band 4 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND4_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 4;
+    lv2:symbol "Band5GainDb";
+    lv2:name "Band 5 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND5_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 5;
+    lv2:symbol "Band6GainDb";
+    lv2:name "Band 6 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND6_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 6;
+    lv2:symbol "Band7GainDb";
+    lv2:name "Band 7 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND7_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 7;
+    lv2:symbol "Band8GainDb";
+    lv2:name "Band 8 Gain [dB]";
+    lv2:default 0;
+    lv2:minimum -50;
+    lv2:maximum 20;
+    epg:group tap_eqbw_lv2:BAND8_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 8;
+    lv2:symbol "Band1FreqHz";
+    lv2:name "Band 1 Freq [Hz]";
+    lv2:default 100;
+    lv2:minimum 40;
+    lv2:maximum 280;
+    epg:group tap_eqbw_lv2:BAND1_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 9;
+    lv2:symbol "Band2FreqHz";
+    lv2:name "Band 2 Freq [Hz]";
+    lv2:default 200;
+    lv2:minimum 100;
+    lv2:maximum 500;
+    epg:group tap_eqbw_lv2:BAND2_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 10;
+    lv2:symbol "Band3FreqHz";
+    lv2:name "Band 3 Freq [Hz]";
+    lv2:default 400;
+    lv2:minimum 200;
+    lv2:maximum 1000;
+    epg:group tap_eqbw_lv2:BAND3_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 11;
+    lv2:symbol "Band4FreqHz";
+    lv2:name "Band 4 Freq [Hz]";
+    lv2:default 1000;
+    lv2:minimum 400;
+    lv2:maximum 2800;
+    epg:group tap_eqbw_lv2:BAND4_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 12;
+    lv2:symbol "Band5FreqHz";
+    lv2:name "Band 5 Freq [Hz]";
+    lv2:default 3000;
+    lv2:minimum 1000;
+    lv2:maximum 5000;
+    epg:group tap_eqbw_lv2:BAND5_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 13;
+    lv2:symbol "Band6FreqHz";
+    lv2:name "Band 6 Freq [Hz]";
+    lv2:default 6000;
+    lv2:minimum 3000;
+    lv2:maximum 9000;
+    epg:group tap_eqbw_lv2:BAND6_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 14;
+    lv2:symbol "Band7FreqHz";
+    lv2:name "Band 7 Freq [Hz]";
+    lv2:default 12000;
+    lv2:minimum 6000;
+    lv2:maximum 18000;
+    epg:group tap_eqbw_lv2:BAND7_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 15;
+    lv2:symbol "Band8FreqHz";
+    lv2:name "Band 8 Freq [Hz]";
+    lv2:default 15000;
+    lv2:minimum 10000;
+    lv2:maximum 20000;
+    epg:group tap_eqbw_lv2:BAND8_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 16;
+    lv2:symbol "Band1BandwidthOctaves";
+    lv2:name "Band 1 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND1_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 17;
+    lv2:symbol "Band2BandwidthOctaves";
+    lv2:name "Band 2 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND2_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 18;
+    lv2:symbol "Band3BandwidthOctaves";
+    lv2:name "Band 3 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND3_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 19;
+    lv2:symbol "Band4BandwidthOctaves";
+    lv2:name "Band 4 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND4_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 20;
+    lv2:symbol "Band5BandwidthOctaves";
+    lv2:name "Band 5 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND5_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 21;
+    lv2:symbol "Band6BandwidthOctaves";
+    lv2:name "Band 6 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND6_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 22;
+    lv2:symbol "Band7BandwidthOctaves";
+    lv2:name "Band 7 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND7_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:ControlPort;
+    lv2:index 23;
+    lv2:symbol "Band8BandwidthOctaves";
+    lv2:name "Band 8 Bandwidth [octaves]";
+    lv2:default 1;
+    lv2:minimum 0.10;
+    lv2:maximum 5;
+    epg:group tap_eqbw_lv2:BAND8_GROUP ;
+],
+[
+    a lv2:InputPort, lv2:AudioPort;
+    lv2:index 24;
+    lv2:symbol "Input";
+    lv2:name "Input";
+],
+[
+    a lv2:OutputPort, lv2:AudioPort;
+    lv2:index 25;
+    lv2:symbol "Output";
+    lv2:name "Output";
+].
+
+tap_eqbw_lv2:BAND1_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND1" ;
+	lv2:name "Band 1" .
+tap_eqbw_lv2:BAND2_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND2" ;
+	lv2:name "Band 2" .
+tap_eqbw_lv2:BAND3_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND3" ;
+	lv2:name "Band 3" .
+tap_eqbw_lv2:BAND4_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND4" ;
+	lv2:name "Band 4" .
+tap_eqbw_lv2:BAND5_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND5" ;
+	lv2:name "Band 5" .
+tap_eqbw_lv2:BAND6_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND6" ;
+	lv2:name "Band 6" .
+tap_eqbw_lv2:BAND7_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND7" ;
+	lv2:name "Band 7" .
+tap_eqbw_lv2:BAND8_GROUP
+	a epg:InputGroup ;
+	lv2:symbol "BAND8" ;
+	lv2:name "Band 8" .

--- a/html/css/pedals.css
+++ b/html/css/pedals.css
@@ -342,7 +342,6 @@ body > .mod-settings.mod-window-visible {
     float:left;
     height:160px;
     margin-bottom:2px;
-    margin-right:2px;
     position:relative;
     text-align:center;
     width:160px;
@@ -388,9 +387,10 @@ body > .mod-settings.mod-window-visible {
     display:block;
     font-size:11px;
     font-weight:bold;
-    height:11px;
+    height:23px;
     line-height:1;
-    margin:9px 0;
+    margin:3px 0;
+    padding:6px 0;
     position:relative;
     overflow:hidden;
     text-transform:uppercase;
@@ -891,6 +891,119 @@ body > .mod-settings.mod-window-visible {
 .mod-pedal-settings-address select {
     width:202px;
 }
+
+/* 32 Groups */
+.mod-pedal-settings .mod-group.mod-group-start > .mod-knob-title {
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+}
+
+.mod-pedal-settings .mod-group.mod-group-end > .mod-knob-title {
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+}
+
+.mod-pedal-settings .mod-group.mod-group-end {
+     margin-right:2px;
+}
+
+.mod-pedal-settings .mod-group-0 > .mod-knob-title {
+    background-color: #DE7558;
+}
+.mod-pedal-settings .mod-group-1 > .mod-knob-title {
+    background-color: #16ACA6;
+}
+.mod-pedal-settings .mod-group-2 > .mod-knob-title {
+    background-color: #74A16B;
+}
+.mod-pedal-settings .mod-group-3 > .mod-knob-title {
+    background-color: #EC2469;
+}
+.mod-pedal-settings .mod-group-4 > .mod-knob-title {
+    background-color: #860FDA;
+}
+.mod-pedal-settings .mod-group-5 > .mod-knob-title {
+    background-color: #D4BA3D;
+}
+.mod-pedal-settings .mod-group-6 > .mod-knob-title {
+    background-color: #819393;
+}
+.mod-pedal-settings .mod-group-7 > .mod-knob-title {
+    background-color: #9951BF;
+}
+.mod-pedal-settings .mod-group-8 > .mod-knob-title {
+    background-color: #DFB6A5;
+}
+.mod-pedal-settings .mod-group-9 > .mod-knob-title {
+    background-color: #B9A843;
+}
+.mod-pedal-settings .mod-group-10 > .mod-knob-title {
+    background-color: #81DEA8;
+}
+.mod-pedal-settings .mod-group-11 > .mod-knob-title {
+    background-color: #AB386B;
+}
+.mod-pedal-settings .mod-group-12 > .mod-knob-title {
+    background-color: #4D80DD;
+}
+.mod-pedal-settings .mod-group-13 > .mod-knob-title {
+    background-color: #EBE65A;
+}
+.mod-pedal-settings .mod-group-14 > .mod-knob-title {
+    background-color: #0B575B;
+}
+.mod-pedal-settings .mod-group-15 > .mod-knob-title {
+    background-color: #5755F7;
+}
+.mod-pedal-settings .mod-group-16 > .mod-knob-title {
+    background-color: #3DC745;
+}
+.mod-pedal-settings .mod-group-17 > .mod-knob-title {
+    background-color: #F51034;
+}
+.mod-pedal-settings .mod-group-18 > .mod-knob-title {
+    background-color: #F91114;
+}
+.mod-pedal-settings .mod-group-19 > .mod-knob-title {
+    background-color: #84D08B;
+}
+.mod-pedal-settings .mod-group-20 > .mod-knob-title {
+    background-color: #CAB8B0;
+}
+.mod-pedal-settings .mod-group-21 > .mod-knob-title {
+    background-color: #425265;
+}
+.mod-pedal-settings .mod-group-22 > .mod-knob-title {
+    background-color: #341B05;
+}
+.mod-pedal-settings .mod-group-23 > .mod-knob-title {
+    background-color: #055538;
+}
+.mod-pedal-settings .mod-group-24 > .mod-knob-title {
+    background-color: #1AE35C;
+}
+.mod-pedal-settings .mod-group-25 > .mod-knob-title {
+    background-color: #9D0B8E;
+}
+.mod-pedal-settings .mod-group-26 > .mod-knob-title {
+    background-color: #6F8C9A;
+}
+.mod-pedal-settings .mod-group-27 > .mod-knob-title {
+    background-color: #069758;
+}
+.mod-pedal-settings .mod-group-28 > .mod-knob-title {
+    background-color: #2340B9;
+}
+.mod-pedal-settings .mod-group-29 > .mod-knob-title {
+    background-color: #3F7CBB;
+}
+.mod-pedal-settings .mod-group-30 > .mod-knob-title {
+    background-color: #8185D4;
+}
+.mod-pedal-settings .mod-group-31 > .mod-knob-title {
+    background-color: #080F1F;
+}
+
 
 /* FIXME put it in the right place */
 .mod-pedal.replaceable-drop {

--- a/html/css/pedals.css
+++ b/html/css/pedals.css
@@ -541,9 +541,10 @@ body > .mod-settings.mod-window-visible {
     display:block;
     font-size:11px;
     font-weight:bold;
-    height:11px;
+    height:23px;
     line-height:1;
-    margin:9px 0;
+    margin:3px 0;
+    padding:6px 0;
     position:relative;
     overflow:hidden;
     text-align:center;
@@ -893,12 +894,12 @@ body > .mod-settings.mod-window-visible {
 }
 
 /* 32 Groups */
-.mod-pedal-settings .mod-group.mod-group-start > .mod-knob-title {
+.mod-pedal-settings .mod-group.mod-group-start > .mod-group-item-title {
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
 }
 
-.mod-pedal-settings .mod-group.mod-group-end > .mod-knob-title {
+.mod-pedal-settings .mod-group.mod-group-end > .mod-group-item-title {
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
 }
@@ -907,100 +908,100 @@ body > .mod-settings.mod-window-visible {
      margin-right:2px;
 }
 
-.mod-pedal-settings .mod-group-0 > .mod-knob-title {
+.mod-pedal-settings .mod-group-0 > .mod-group-item-title {
     background-color: #DE7558;
 }
-.mod-pedal-settings .mod-group-1 > .mod-knob-title {
+.mod-pedal-settings .mod-group-1 > .mod-group-item-title {
     background-color: #16ACA6;
 }
-.mod-pedal-settings .mod-group-2 > .mod-knob-title {
+.mod-pedal-settings .mod-group-2 > .mod-group-item-title {
     background-color: #74A16B;
 }
-.mod-pedal-settings .mod-group-3 > .mod-knob-title {
+.mod-pedal-settings .mod-group-3 > .mod-group-item-title {
     background-color: #EC2469;
 }
-.mod-pedal-settings .mod-group-4 > .mod-knob-title {
+.mod-pedal-settings .mod-group-4 > .mod-group-item-title {
     background-color: #860FDA;
 }
-.mod-pedal-settings .mod-group-5 > .mod-knob-title {
+.mod-pedal-settings .mod-group-5 > .mod-group-item-title {
     background-color: #D4BA3D;
 }
-.mod-pedal-settings .mod-group-6 > .mod-knob-title {
+.mod-pedal-settings .mod-group-6 > .mod-group-item-title {
     background-color: #819393;
 }
-.mod-pedal-settings .mod-group-7 > .mod-knob-title {
+.mod-pedal-settings .mod-group-7 > .mod-group-item-title {
     background-color: #9951BF;
 }
-.mod-pedal-settings .mod-group-8 > .mod-knob-title {
+.mod-pedal-settings .mod-group-8 > .mod-group-item-title {
     background-color: #DFB6A5;
 }
-.mod-pedal-settings .mod-group-9 > .mod-knob-title {
+.mod-pedal-settings .mod-group-9 > .mod-group-item-title {
     background-color: #B9A843;
 }
-.mod-pedal-settings .mod-group-10 > .mod-knob-title {
+.mod-pedal-settings .mod-group-10 > .mod-group-item-title {
     background-color: #81DEA8;
 }
-.mod-pedal-settings .mod-group-11 > .mod-knob-title {
+.mod-pedal-settings .mod-group-11 > .mod-group-item-title {
     background-color: #AB386B;
 }
-.mod-pedal-settings .mod-group-12 > .mod-knob-title {
+.mod-pedal-settings .mod-group-12 > .mod-group-item-title {
     background-color: #4D80DD;
 }
-.mod-pedal-settings .mod-group-13 > .mod-knob-title {
+.mod-pedal-settings .mod-group-13 > .mod-group-item-title {
     background-color: #EBE65A;
 }
-.mod-pedal-settings .mod-group-14 > .mod-knob-title {
+.mod-pedal-settings .mod-group-14 > .mod-group-item-title {
     background-color: #0B575B;
 }
-.mod-pedal-settings .mod-group-15 > .mod-knob-title {
+.mod-pedal-settings .mod-group-15 > .mod-group-item-title {
     background-color: #5755F7;
 }
-.mod-pedal-settings .mod-group-16 > .mod-knob-title {
+.mod-pedal-settings .mod-group-16 > .mod-group-item-title {
     background-color: #3DC745;
 }
-.mod-pedal-settings .mod-group-17 > .mod-knob-title {
+.mod-pedal-settings .mod-group-17 > .mod-group-item-title {
     background-color: #F51034;
 }
-.mod-pedal-settings .mod-group-18 > .mod-knob-title {
+.mod-pedal-settings .mod-group-18 > .mod-group-item-title {
     background-color: #F91114;
 }
-.mod-pedal-settings .mod-group-19 > .mod-knob-title {
+.mod-pedal-settings .mod-group-19 > .mod-group-item-title {
     background-color: #84D08B;
 }
-.mod-pedal-settings .mod-group-20 > .mod-knob-title {
+.mod-pedal-settings .mod-group-20 > .mod-group-item-title {
     background-color: #CAB8B0;
 }
-.mod-pedal-settings .mod-group-21 > .mod-knob-title {
+.mod-pedal-settings .mod-group-21 > .mod-group-item-title {
     background-color: #425265;
 }
-.mod-pedal-settings .mod-group-22 > .mod-knob-title {
+.mod-pedal-settings .mod-group-22 > .mod-group-item-title {
     background-color: #341B05;
 }
-.mod-pedal-settings .mod-group-23 > .mod-knob-title {
+.mod-pedal-settings .mod-group-23 > .mod-group-item-title {
     background-color: #055538;
 }
-.mod-pedal-settings .mod-group-24 > .mod-knob-title {
+.mod-pedal-settings .mod-group-24 > .mod-group-item-title {
     background-color: #1AE35C;
 }
-.mod-pedal-settings .mod-group-25 > .mod-knob-title {
+.mod-pedal-settings .mod-group-25 > .mod-group-item-title {
     background-color: #9D0B8E;
 }
-.mod-pedal-settings .mod-group-26 > .mod-knob-title {
+.mod-pedal-settings .mod-group-26 > .mod-group-item-title {
     background-color: #6F8C9A;
 }
-.mod-pedal-settings .mod-group-27 > .mod-knob-title {
+.mod-pedal-settings .mod-group-27 > .mod-group-item-title {
     background-color: #069758;
 }
-.mod-pedal-settings .mod-group-28 > .mod-knob-title {
+.mod-pedal-settings .mod-group-28 > .mod-group-item-title {
     background-color: #2340B9;
 }
-.mod-pedal-settings .mod-group-29 > .mod-knob-title {
+.mod-pedal-settings .mod-group-29 > .mod-group-item-title {
     background-color: #3F7CBB;
 }
-.mod-pedal-settings .mod-group-30 > .mod-knob-title {
+.mod-pedal-settings .mod-group-30 > .mod-group-item-title {
     background-color: #8185D4;
 }
-.mod-pedal-settings .mod-group-31 > .mod-knob-title {
+.mod-pedal-settings .mod-group-31 > .mod-group-item-title {
     background-color: #080F1F;
 }
 

--- a/html/resources/settings.html
+++ b/html/resources/settings.html
@@ -107,7 +107,7 @@
             {{^enumeration}}
                 {{^trigger}}
                     {{^toggled}}
-                    <div class="mod-knob" title="{{comment}}">
+                    <div class="mod-knob{{#group}} mod-group{{#groupStart}} mod-group-start{{/groupStart}} mod-group-{{groupIndex}}{{#groupEnd}} mod-group-end{{/groupEnd}}{{/group}}" title="{{comment}}">
                         <span class="mod-knob-title">{{shortName}}</span>
                         <span class="mod-knob-min-value" mod-role="input-control-minimum" mod-port-symbol="{{symbol}}"></span>
                         <span class="mod-knob-max-value" mod-role="input-control-maximum" mod-port-symbol="{{symbol}}"></span>

--- a/html/resources/settings.html
+++ b/html/resources/settings.html
@@ -94,8 +94,8 @@
 
             {{#effect.ports.control.input}}
             {{#enumeration}}
-            <div class="mod-enumerated">
-                <span class="mod-enumerated-title">{{shortName}}</span>
+            <div class="mod-enumerated{{#group}} mod-group{{#groupStart}} mod-group-start{{/groupStart}} mod-group-{{groupIndex}}{{#groupEnd}} mod-group-end{{/groupEnd}}{{/group}}">
+                <span class="mod-enumerated-title{{#group}} mod-group-item-title{{/group}}">{{shortName}}</span>
                 <div class="mod-address" mod-role="input-control-address" mod-port-symbol="{{symbol}}"></div>
                 <div class="mod-enumerated-list" mod-role="input-control-port" mod-port-symbol="{{symbol}}" mod-widget="custom-select">
                     {{#scalePoints}}
@@ -108,7 +108,7 @@
                 {{^trigger}}
                     {{^toggled}}
                     <div class="mod-knob{{#group}} mod-group{{#groupStart}} mod-group-start{{/groupStart}} mod-group-{{groupIndex}}{{#groupEnd}} mod-group-end{{/groupEnd}}{{/group}}" title="{{comment}}">
-                        <span class="mod-knob-title">{{shortName}}</span>
+                        <span class="mod-knob-title{{#group}} mod-group-item-title{{/group}}">{{shortName}}</span>
                         <span class="mod-knob-min-value" mod-role="input-control-minimum" mod-port-symbol="{{symbol}}"></span>
                         <span class="mod-knob-max-value" mod-role="input-control-maximum" mod-port-symbol="{{symbol}}"></span>
                         <span class="mod-knob-current-value" mod-role="input-control-value" mod-port-symbol="{{symbol}}"></span>

--- a/modtools/utils.py
+++ b/modtools/utils.py
@@ -185,6 +185,13 @@ class PluginAuthor(Structure):
         ("email", c_char_p),
     ]
 
+class PluginPortGroup(Structure):
+    _fields_ = [
+        ("valid", c_bool),
+        ("symbol", c_char_p),
+        ("name", c_char_p),
+    ]
+
 class PluginGUIPort(Structure):
     _fields_ = [
         ("valid", c_bool),
@@ -257,6 +264,7 @@ class PluginPort(Structure):
         ("rangeSteps", c_int),
         ("scalePoints", POINTER(PluginPortScalePoint)),
         ("shortName", c_char_p),
+        ("groupSymbol", c_char_p),
     ]
 
 class PluginPortsI(Structure):
@@ -345,6 +353,7 @@ class PluginInfo(Structure):
         ("ports", PluginPorts),
         ("parameters", POINTER(PluginParameter)),
         ("presets", POINTER(PluginPreset)),
+        ("portGroups", POINTER(PluginPortGroup)),
     ]
 
 # a subset of PluginInfo
@@ -517,6 +526,7 @@ TrueBypassStateChanged = CFUNCTYPE(None, c_bool, c_bool)
 CvExpInputModeChanged = CFUNCTYPE(None, c_bool)
 
 c_struct_types = (PluginAuthor,
+                  PluginPortGroup,
                   PluginGUI,
                   PluginGUI_Mini,
                   PluginPortRanges,
@@ -533,6 +543,7 @@ c_structp_types = (POINTER(PluginGUIPort),
                    POINTER(PluginPort),
                    POINTER(PluginParameter),
                    POINTER(PluginPreset),
+                   POINTER(PluginPortGroup),
                    POINTER(PedalboardPlugin),
                    POINTER(PedalboardConnection),
                    POINTER(PedalboardPluginPort),

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -2,8 +2,6 @@
 CC  ?= gcc
 CXX ?= g++
 
-DEBUG=1
-
 TARGET_MACHINE := $(shell $(CC) -dumpmachine)
 
 ifneq (,$(findstring apple,$(TARGET_MACHINE)))

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -2,6 +2,8 @@
 CC  ?= gcc
 CXX ?= g++
 
+DEBUG=1
+
 TARGET_MACHINE := $(shell $(CC) -dumpmachine)
 
 ifneq (,$(findstring apple,$(TARGET_MACHINE)))

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -45,6 +45,12 @@ typedef struct {
 
 typedef struct {
     bool valid;
+    const char* symbol;
+    const char* name;
+} PluginPortGroup;
+
+typedef struct {
+    bool valid;
     unsigned int index;
     const char* name;
     const char* symbol;
@@ -108,6 +114,7 @@ typedef struct {
     int rangeSteps;
     const PluginPortScalePoint* scalePoints;
     const char* shortName;
+    const char* groupSymbol;
 } PluginPort;
 
 typedef struct {
@@ -187,6 +194,7 @@ typedef struct {
     PluginPorts ports;
     const PluginParameter* parameters;
     const PluginPreset* presets;
+    const PluginPortGroup* portGroups;
 } PluginInfo;
 
 typedef struct {

--- a/utils/utils_lilv.cpp
+++ b/utils/utils_lilv.cpp
@@ -2930,7 +2930,7 @@ const PluginInfo& _get_plugin_info(LilvWorld* const w,
 
             // ----------------------------------------------------------------------------------------------------
             // groups
-            portinfo.groupSymbol = nullptr;
+            portinfo.groupSymbol = nc;
             if (const LilvNode* const symbolnode = lilv_port_get(p, port, ns.port_groups_groupName))
             {
                 const char* groupName = lilv_node_as_string(symbolnode);


### PR DESCRIPTION
# What is?

This is a first (partial) implementation of lv2 port groups extensions for mod-ui:

https://forum.mod.audio/t/support-in-mod-ui-for-lv2-port-group-extension/12798

It involve only the effect settings dialog and nothing more.

## Why

Sometimes find the right control in the settings effect dialog is difficult.

The feature has some valuable pros and cons.

Pros:

* Better control grouping and a more user friendly UX in particular for mixer style plugins

Cons:

* In order to support port groups the ttl of every plugin should be edited
* The specification doesn't allow customizionation of labels in order to have a label when the host supports groups and a different one when not. This renders useless the group name for any pratical case.

### Example screenshots

Tap eq before:

![tapeq_before](https://github.com/user-attachments/assets/8659c0af-5f8e-4dbd-ba96-e304895c5e6d)

Tap eq after:

![tapeq_after](https://github.com/user-attachments/assets/9b350c0d-bba0-4724-9408-198297f24e8c)

# Code Notes

## Ttl files

In the `example-port-group-ttls` folder I added some files with added port group annotations, these file should be copied on the relevant bundle directories in order to test the patch.

## CPP backend

I tried various approaches and in the end I decided to load and cache groups while reading plugin ports. 

A first implementation was loading all the groups defined in advance and then associate every group with the right plugin port, but I didn't like it because lilv doesn't allow to query nodes using **partial** wildcard on a subject so for each plugin I had to iterate over all the world group to match the right one: a waste of resource.

I think that I got all the memory management right, but a review from a more expert cpp developer is very welcome.

## Python

Nothing special there, just bindings updates to the cpp structure involved

## HTML / JS

My approach was to move the port group logic on the client side in order to spare some cpu cycles from the python server.

The code I'm talking is here: html/js/host.js row 374

The other relevant changes are in the css and settings templates:

* I used mustaches conditional syntax to add the relevant port group classes on the knob & enumerated controls
* I create a css class `.mod-group-item-title` in order customize all the title easly

In the end I really don't get all the structure and details of this part of mod ui, but the solution seam to work well.