### PR TITLE
Support for Easy Spin programs in the UI

### DIFF
--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -2223,6 +2223,9 @@ class FilesList(JsonRequestHandler):
         elif filetype == "nammodel":
             return ("NAM Models", (".nam",))
 
+        elif filetype == "easyspinprog":
+            return ("Easy Spin Programs", (".bin",))
+
         else:
             return (None, ())
 

--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -2224,7 +2224,7 @@ class FilesList(JsonRequestHandler):
             return ("NAM Models", (".nam",))
 
         elif filetype == "easyspinprog":
-            return ("Easy Spin Programs", (".bin",))
+            return ("Easy Spin Programs", (".json",".bin",))
 
         else:
             return (None, ())

--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -2224,7 +2224,7 @@ class FilesList(JsonRequestHandler):
             return ("NAM Models", (".nam",))
 
         elif filetype == "easyspinprog":
-            return ("Easy Spin Programs", (".easyspinprog",))
+            return ("Easy Spin Programs", (".json",))
 
         else:
             return (None, ())

--- a/mod/webserver.py
+++ b/mod/webserver.py
@@ -2224,7 +2224,7 @@ class FilesList(JsonRequestHandler):
             return ("NAM Models", (".nam",))
 
         elif filetype == "easyspinprog":
-            return ("Easy Spin Programs", (".json",".bin",))
+            return ("Easy Spin Programs", (".easyspinprog",))
 
         else:
             return (None, ())


### PR DESCRIPTION
Adds a new file-type entry to FilesList so the Audiofab Easy Spin LV2
plugin (https://audiofab.com/plugins/easy-spin) can expose a dedicated
"Easy Spin Programs" folder in MOD UI's Files tab for user-uploaded
FV-1 program binaries (.json).

The plugin emulates Audiofab's FV-1-based Easy Spin in real time and
loads compiled 512-byte FV-1 binaries as user effects. Without this
entry, plugins that set mod:fileTypes "easyspinprog" get an empty
file picker.

Follows the same pattern as the recent "aidadspmodel" / "nammodel"
additions — single elif clause, no UI changes needed.

NOTE: The plugin is ready to go - I am just looking at how to get it published. It is effectively this:

https://easy-spin.audiofab.com

But running on the MOD Dwarf. And you can use the Easy Spin tools (https://marketplace.visualstudio.com/items?itemName=ms-audiofab.fv1-vscode) to write your own effects and upload them to run on the Dwarf as well.